### PR TITLE
Minor modernization update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ documentation = "https://docs.rs/twapi"
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1.48"
 base64 = "0.22.1"
 url = "2.2.1"
 serde_json = "^1.0"
@@ -24,3 +23,4 @@ tokio = { version = "^1", features = ["fs", "time"] }
 
 [features]
 account-activity = [ "ipnetwork" ]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ipnetwork = { version = "0.20.0", optional = true }
 serde_urlencoded = "0.7.0"
 twapi-reqwest = "^0.3"
 #twapi-reqwest = { path = "../twapi-reqwest-rs" }
-tokio = { version = "^1", features = ["time"] }
+tokio = { version = "^1", features = ["fs", "time"] }
 
 [features]
 account-activity = [ "ipnetwork" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ url = "2.2.1"
 serde_json = "^1.0"
 ipnetwork = { version = "0.17.0", optional = true }
 serde_urlencoded = "0.7.0"
-twapi-reqwest = "^0.2"
+twapi-reqwest = "^0.3"
 #twapi-reqwest = { path = "../twapi-reqwest-rs" }
 tokio = { version = "^1", features = ["time"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.48"
-base64 = "0.13.0"
+base64 = "0.22.1"
 url = "2.2.1"
 serde_json = "^1.0"
-ipnetwork = { version = "0.17.0", optional = true }
+ipnetwork = { version = "0.20.0", optional = true }
 serde_urlencoded = "0.7.0"
 twapi-reqwest = "^0.3"
 #twapi-reqwest = { path = "../twapi-reqwest-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ documentation = "https://docs.rs/twapi"
 edition = "2018"
 
 [dependencies]
-async-trait = "~0.1.48"
-base64 = "~0.13.0"
-url = "~2.2.1"
+async-trait = "0.1.48"
+base64 = "0.13.0"
+url = "2.2.1"
 serde_json = "^1.0"
-ipnetwork = { version = "~0.17.0", optional = true }
-serde_urlencoded = "~0.7.0"
+ipnetwork = { version = "0.17.0", optional = true }
+serde_urlencoded = "0.7.0"
 twapi-reqwest = "^0.2"
 #twapi-reqwest = { path = "../twapi-reqwest-rs" }
 tokio = { version = "^1", features = ["time"] }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## Unreleased
+- Loosened dependency version requirements for `base64`, `url`, and `serde_urlencoded`
+- Update depenendcy major versions across the board
+- Remove `async-trait` in favor of native async traits
+- Use async filesystem I/O in async functions
+- Simplify file I/O for media uploads
+- Cleanup assorted Clippy lints
+
 ## 0.7.0 (2021/03/26)
 - updated twapi-reqwest 0.0
 - updated tokio 1.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A simple Twitter library. This is easy for customize.
 #![allow(clippy::ptr_arg)] // Underlying twapi-reqwest requires &Vec args
 use core::future::Future;
-use std::{io::Cursor, time};
+use std::time;
 
 use tokio::io::{AsyncReadExt, BufReader};
 use twapi_reqwest::reqwest::{
@@ -392,13 +392,13 @@ pub trait Twapi: Send + Sync {
                 } else {
                     (file_size - segment_index * 5000000) as usize
                 };
-                let mut cursor = Cursor::new(vec![0; read_size]);
-                reader.read_exact(cursor.get_mut()).await?;
+                let mut buffer = vec![0; read_size];
+                reader.read_exact(&mut buffer).await?;
                 let form = Form::new()
                     .text("command", "APPEND")
                     .text("media_id", media_id.clone())
                     .text("segment_index", segment_index.to_string())
-                    .part("media", Part::bytes(cursor.into_inner()));
+                    .part("media", Part::bytes(buffer));
 
                 let response = self
                     .multipart(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,7 +554,7 @@ impl ApplicationAuth {
 #[async_trait]
 impl Twapi for ApplicationAuth {
     async fn get(&self, uri: &str, query_options: &Vec<(&str, &str)>) -> TResult {
-        twapi_reqwest::v2::get(uri, query_options, &self.bearer_token).await
+        twapi_reqwest::v2::get(uri, query_options, &self.bearer_token, None).await
     }
 
     async fn post(
@@ -563,19 +563,19 @@ impl Twapi for ApplicationAuth {
         query_options: &Vec<(&str, &str)>,
         form_options: &Vec<(&str, &str)>,
     ) -> TResult {
-        twapi_reqwest::v2::post(uri, query_options, form_options, &self.bearer_token).await
+        twapi_reqwest::v2::post(uri, query_options, form_options, &self.bearer_token, None).await
     }
 
     async fn multipart(&self, uri: &str, query_options: &Vec<(&str, &str)>, form: Form) -> TResult {
-        twapi_reqwest::v2::multipart(uri, query_options, form, &self.bearer_token).await
+        twapi_reqwest::v2::multipart(uri, query_options, form, &self.bearer_token, None).await
     }
 
     async fn put(&self, uri: &str, query_options: &Vec<(&str, &str)>) -> TResult {
-        twapi_reqwest::v2::put(uri, query_options, &self.bearer_token).await
+        twapi_reqwest::v2::put(uri, query_options, &self.bearer_token, None).await
     }
 
     async fn delete(&self, uri: &str, query_options: &Vec<(&str, &str)>) -> TResult {
-        twapi_reqwest::v2::delete(uri, query_options, &self.bearer_token).await
+        twapi_reqwest::v2::delete(uri, query_options, &self.bearer_token, None).await
     }
 
     async fn json(
@@ -584,7 +584,7 @@ impl Twapi for ApplicationAuth {
         query_options: &Vec<(&str, &str)>,
         json: &serde_json::Value,
     ) -> TResult {
-        twapi_reqwest::v2::json(uri, query_options, json, &self.bearer_token).await
+        twapi_reqwest::v2::json(uri, query_options, json, &self.bearer_token, None).await
     }
 }
 
@@ -622,6 +622,7 @@ impl Twapi for UserAuth {
             &self.consumer_secret,
             &self.access_token,
             &self.access_token_secret,
+            None,
         )
         .await
     }
@@ -640,6 +641,7 @@ impl Twapi for UserAuth {
             &self.consumer_secret,
             &self.access_token,
             &self.access_token_secret,
+            None,
         )
         .await
     }
@@ -653,6 +655,7 @@ impl Twapi for UserAuth {
             &self.consumer_secret,
             &self.access_token,
             &self.access_token_secret,
+            None,
         )
         .await
     }
@@ -665,6 +668,7 @@ impl Twapi for UserAuth {
             &self.consumer_secret,
             &self.access_token,
             &self.access_token_secret,
+            None,
         )
         .await
     }
@@ -677,6 +681,7 @@ impl Twapi for UserAuth {
             &self.consumer_secret,
             &self.access_token,
             &self.access_token_secret,
+            None,
         )
         .await
     }
@@ -695,6 +700,7 @@ impl Twapi for UserAuth {
             &self.consumer_secret,
             &self.access_token,
             &self.access_token_secret,
+            None,
         )
         .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,9 +275,8 @@ pub trait Twapi {
         additional_owners: Option<String>,
     ) -> Result<TwapiResponse, TwapiError> {
         let buffer = tokio::fs::read(file).await.unwrap();
-        let cursor = Cursor::new(buffer);
 
-        let part = Part::bytes(cursor.into_inner());
+        let part = Part::bytes(buffer);
         let form = Form::new().part("media", part);
         let form = if let Some(additional_owners) = additional_owners {
             form.text("additional_owners", additional_owners)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //! A simple Twitter library. This is easy for customize.
 #![allow(clippy::ptr_arg)] // Underlying twapi-reqwest requires &Vec args
-use async_trait::async_trait;
+use core::future::Future;
 use std::{io::Cursor, time};
+
 use tokio::io::{AsyncReadExt, BufReader};
 use twapi_reqwest::reqwest::{
     multipart::{Form, Part},
@@ -92,265 +93,330 @@ fn make_account_activity_uri(
 }
 
 /// Access to Twitter API
-#[async_trait]
-pub trait Twapi {
-    async fn get(&self, uri: &str, query_options: &Vec<(&str, &str)>) -> TResult;
-    async fn post(
+pub trait Twapi: Send + Sync {
+    fn get(
+        &self,
+        uri: &str,
+        query_options: &Vec<(&str, &str)>,
+    ) -> impl Future<Output = TResult> + Send;
+    fn post(
         &self,
         uri: &str,
         query_options: &Vec<(&str, &str)>,
         form_options: &Vec<(&str, &str)>,
-    ) -> TResult;
+    ) -> impl Future<Output = TResult> + Send;
 
-    async fn multipart(&self, uri: &str, query_options: &Vec<(&str, &str)>, form: Form) -> TResult;
+    fn multipart(
+        &self,
+        uri: &str,
+        query_options: &Vec<(&str, &str)>,
+        form: Form,
+    ) -> impl Future<Output = TResult> + Send;
 
-    async fn put(&self, uri: &str, query_options: &Vec<(&str, &str)>) -> TResult;
+    fn put(
+        &self,
+        uri: &str,
+        query_options: &Vec<(&str, &str)>,
+    ) -> impl Future<Output = TResult> + Send;
 
-    async fn delete(&self, uri: &str, query_options: &Vec<(&str, &str)>) -> TResult;
+    fn delete(
+        &self,
+        uri: &str,
+        query_options: &Vec<(&str, &str)>,
+    ) -> impl Future<Output = TResult> + Send;
 
-    async fn json(
+    fn json(
         &self,
         uri: &str,
         query_options: &Vec<(&str, &str)>,
         json: &serde_json::Value,
-    ) -> TResult;
+    ) -> impl Future<Output = TResult> + Send;
 
-    async fn get_verify_credentials(
+    fn get_verify_credentials(
         &self,
         params: &Vec<(&str, &str)>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                "https://api.twitter.com/1.1/account/verify_credentials.json",
-                params,
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn get_search_tweets(
-        &self,
-        params: &Vec<(&str, &str)>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get("https://api.twitter.com/1.1/search/tweets.json", params)
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn post_statuses_update(
-        &self,
-        params: &Vec<(&str, &str)>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .post(
-                "https://api.twitter.com/1.1/statuses/update.json",
-                &vec![],
-                params,
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn post_direct_messages_events_new(
-        &self,
-        value: &serde_json::Value,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .json(
-                "https://api.twitter.com/1.1/direct_messages/events/new.json",
-                &vec![],
-                value,
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn get_account_activity_subscription(
-        &self,
-        env_name: &str,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                format!(
-                    "https://api.twitter.com/1.1/account_activity/all/{}/subscriptions.json",
-                    env_name
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    "https://api.twitter.com/1.1/account/verify_credentials.json",
+                    params,
                 )
-                .as_str(),
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn get_direct_messages_welcome_messages_list(&self) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                "https://api.twitter.com/1.1/direct_messages/welcome_messages/list.json",
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn get_direct_messages_welcome_messages_show(
-        &self,
-        id: &str,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                "https://api.twitter.com/1.1/direct_messages/welcome_messages/show.json",
-                &vec![("id", id)],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn post_direct_messages_welcome_messages_new(
-        &self,
-        value: &serde_json::Value,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .json(
-                "https://api.twitter.com/1.1/direct_messages/welcome_messages/new.json",
-                &vec![],
-                value,
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn delete_direct_messages_welcome_messages_destroy(
-        &self,
-        id: &str,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .delete(
-                "https://api.twitter.com/1.1/direct_messages/welcome_messages/destroy.json",
-                &vec![("id", id)],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn get_media_upload(&self, media_id: &str) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                "https://upload.twitter.com/1.1/media/upload.json",
-                &vec![("command", "STATUS"), ("media_id", media_id)],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
-    }
-
-    async fn get_media_upload_until_succeeded(
-        &self,
-        media_id: &str,
-    ) -> Result<TwapiResponse, TwapiError> {
-        loop {
-            let check_after_secs = {
-                let result = self.get_media_upload(media_id).await?;
-                if !result.is_success() {
-                    return Ok(result);
-                }
-                let json = result.copy_json_value().unwrap();
-                let processing_info = json.get("processing_info").unwrap();
-                let state = String::from(processing_info.get("state").unwrap().as_str().unwrap());
-                if state == "succeeded" || state == "failed" {
-                    return Ok(result);
-                }
-                processing_info
-                    .get("check_after_secs")
-                    .unwrap()
-                    .as_u64()
-                    .unwrap()
-            };
-            tokio::time::sleep(time::Duration::new(check_after_secs, 0)).await;
+                .await?;
+            Ok(TwapiResponse::new(res).await)
         }
     }
 
-    async fn post_media_upload(
+    fn get_search_tweets(
+        &self,
+        params: &Vec<(&str, &str)>,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get("https://api.twitter.com/1.1/search/tweets.json", params)
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn post_statuses_update(
+        &self,
+        params: &Vec<(&str, &str)>,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .post(
+                    "https://api.twitter.com/1.1/statuses/update.json",
+                    &vec![],
+                    params,
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn post_direct_messages_events_new(
+        &self,
+        value: &serde_json::Value,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .json(
+                    "https://api.twitter.com/1.1/direct_messages/events/new.json",
+                    &vec![],
+                    value,
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn get_account_activity_subscription(
+        &self,
+        env_name: &str,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    format!(
+                        "https://api.twitter.com/1.1/account_activity/all/{}/subscriptions.json",
+                        env_name
+                    )
+                    .as_str(),
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn get_direct_messages_welcome_messages_list(
+        &self,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    "https://api.twitter.com/1.1/direct_messages/welcome_messages/list.json",
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn get_direct_messages_welcome_messages_show(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    "https://api.twitter.com/1.1/direct_messages/welcome_messages/show.json",
+                    &vec![("id", id)],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn post_direct_messages_welcome_messages_new(
+        &self,
+        value: &serde_json::Value,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .json(
+                    "https://api.twitter.com/1.1/direct_messages/welcome_messages/new.json",
+                    &vec![],
+                    value,
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn delete_direct_messages_welcome_messages_destroy(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .delete(
+                    "https://api.twitter.com/1.1/direct_messages/welcome_messages/destroy.json",
+                    &vec![("id", id)],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn get_media_upload(
+        &self,
+        media_id: &str,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    "https://upload.twitter.com/1.1/media/upload.json",
+                    &vec![("command", "STATUS"), ("media_id", media_id)],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
+    }
+
+    fn get_media_upload_until_succeeded(
+        &self,
+        media_id: &str,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            loop {
+                let check_after_secs = {
+                    let result = self.get_media_upload(media_id).await?;
+                    if !result.is_success() {
+                        return Ok(result);
+                    }
+                    let json = result.copy_json_value().unwrap();
+                    let processing_info = json.get("processing_info").unwrap();
+                    let state =
+                        String::from(processing_info.get("state").unwrap().as_str().unwrap());
+                    if state == "succeeded" || state == "failed" {
+                        return Ok(result);
+                    }
+                    processing_info
+                        .get("check_after_secs")
+                        .unwrap()
+                        .as_u64()
+                        .unwrap()
+                };
+                tokio::time::sleep(time::Duration::new(check_after_secs, 0)).await;
+            }
+        }
+    }
+
+    fn post_media_upload(
         &self,
         file: &str,
         additional_owners: Option<String>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let buffer = tokio::fs::read(file).await.unwrap();
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let buffer = tokio::fs::read(file).await.unwrap();
 
-        let part = Part::bytes(buffer);
-        let form = Form::new().part("media", part);
-        let form = if let Some(additional_owners) = additional_owners {
-            form.text("additional_owners", additional_owners)
-        } else {
-            form
-        };
-        let res = self
-            .multipart(
-                "https://upload.twitter.com/1.1/media/upload.json",
-                &vec![],
-                form,
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+            let part = Part::bytes(buffer);
+            let form = Form::new().part("media", part);
+            let form = if let Some(additional_owners) = additional_owners {
+                form.text("additional_owners", additional_owners)
+            } else {
+                form
+            };
+            let res = self
+                .multipart(
+                    "https://upload.twitter.com/1.1/media/upload.json",
+                    &vec![],
+                    form,
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn post_media_upload_chunk(
+    fn post_media_upload_chunk(
         &self,
         file: &str,
         media_type: &str,
         media_category: &str,
         additional_owners: Option<String>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let metadata = tokio::fs::metadata(file).await?;
-        let file_size = metadata.len();
-        let form = Form::new()
-            .text("command", "INIT")
-            .text("total_bytes", file_size.to_string())
-            .text("media_type", String::from(media_type))
-            .text("media_category", String::from(media_category));
-        let form = if let Some(additional_owners) = additional_owners {
-            form.text("additional_owners", additional_owners)
-        } else {
-            form
-        };
-        let media_id = {
-            let response = self
-                .multipart(
-                    "https://upload.twitter.com/1.1/media/upload.json",
-                    &vec![],
-                    form,
-                )
-                .await?;
-            let result = TwapiResponse::new(response).await;
-            if !result.is_success() {
-                return Ok(result);
-            }
-            String::from(
-                result
-                    .json
-                    .unwrap()
-                    .get("media_id_string")
-                    .unwrap()
-                    .as_str()
-                    .unwrap(),
-            )
-        };
-
-        let mut segment_index = 0;
-        let f = tokio::fs::File::open(file).await?;
-        let mut reader = BufReader::new(f);
-        while segment_index * 5000000 < file_size {
-            let read_size: usize = if (segment_index + 1) * 5000000 < file_size {
-                5000000
-            } else {
-                (file_size - segment_index * 5000000) as usize
-            };
-            let mut cursor = Cursor::new(vec![0; read_size]);
-            reader.read_exact(cursor.get_mut()).await?;
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let metadata = tokio::fs::metadata(file).await?;
+            let file_size = metadata.len();
             let form = Form::new()
-                .text("command", "APPEND")
-                .text("media_id", media_id.clone())
-                .text("segment_index", segment_index.to_string())
-                .part("media", Part::bytes(cursor.into_inner()));
+                .text("command", "INIT")
+                .text("total_bytes", file_size.to_string())
+                .text("media_type", String::from(media_type))
+                .text("media_category", String::from(media_category));
+            let form = if let Some(additional_owners) = additional_owners {
+                form.text("additional_owners", additional_owners)
+            } else {
+                form
+            };
+            let media_id = {
+                let response = self
+                    .multipart(
+                        "https://upload.twitter.com/1.1/media/upload.json",
+                        &vec![],
+                        form,
+                    )
+                    .await?;
+                let result = TwapiResponse::new(response).await;
+                if !result.is_success() {
+                    return Ok(result);
+                }
+                String::from(
+                    result
+                        .json
+                        .unwrap()
+                        .get("media_id_string")
+                        .unwrap()
+                        .as_str()
+                        .unwrap(),
+                )
+            };
+
+            let mut segment_index = 0;
+            let f = tokio::fs::File::open(file).await?;
+            let mut reader = BufReader::new(f);
+            while segment_index * 5000000 < file_size {
+                let read_size: usize = if (segment_index + 1) * 5000000 < file_size {
+                    5000000
+                } else {
+                    (file_size - segment_index * 5000000) as usize
+                };
+                let mut cursor = Cursor::new(vec![0; read_size]);
+                reader.read_exact(cursor.get_mut()).await?;
+                let form = Form::new()
+                    .text("command", "APPEND")
+                    .text("media_id", media_id.clone())
+                    .text("segment_index", segment_index.to_string())
+                    .part("media", Part::bytes(cursor.into_inner()));
+
+                let response = self
+                    .multipart(
+                        "https://upload.twitter.com/1.1/media/upload.json",
+                        &vec![],
+                        form,
+                    )
+                    .await?;
+                segment_index += 1;
+                let result = TwapiResponse::new(response).await;
+                if !result.is_success() {
+                    return Ok(result);
+                }
+            }
+
+            let form = Form::new()
+                .text("command", "FINALIZE")
+                .text("media_id", media_id.clone());
 
             let response = self
                 .multipart(
@@ -359,170 +425,175 @@ pub trait Twapi {
                     form,
                 )
                 .await?;
-            segment_index += 1;
             let result = TwapiResponse::new(response).await;
             if !result.is_success() {
                 return Ok(result);
             }
-        }
-
-        let form = Form::new()
-            .text("command", "FINALIZE")
-            .text("media_id", media_id.clone());
-
-        let response = self
-            .multipart(
-                "https://upload.twitter.com/1.1/media/upload.json",
-                &vec![],
-                form,
-            )
-            .await?;
-        let result = TwapiResponse::new(response).await;
-        if !result.is_success() {
-            return Ok(result);
-        }
-        let json = result.copy_json_value().unwrap();
-        let processing_info = json.get("processing_info");
-        if processing_info.is_none() {
-            Ok(result)
-        } else {
-            // check only processing_info included.
-            // if not included call then you get "Invalid mediaId.".
-            self.get_media_upload_until_succeeded(&media_id).await
+            let json = result.copy_json_value().unwrap();
+            let processing_info = json.get("processing_info");
+            if processing_info.is_none() {
+                Ok(result)
+            } else {
+                // check only processing_info included.
+                // if not included call then you get "Invalid mediaId.".
+                self.get_media_upload_until_succeeded(&media_id).await
+            }
         }
     }
 
-    async fn post_media_metadata_create(
+    fn post_media_metadata_create(
         &self,
         value: &serde_json::Value,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .json(
-                "https://upload.twitter.com/1.1/media/metadata/create.json",
-                &vec![],
-                value,
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .json(
+                    "https://upload.twitter.com/1.1/media/metadata/create.json",
+                    &vec![],
+                    value,
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn post_account_activity_webhooks(
+    fn post_account_activity_webhooks(
         &self,
         uri: &str,
         env_name: Option<&str>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .post(
-                &make_account_activity_uri("webhooks", env_name, None),
-                &vec![("url", uri)],
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .post(
+                    &make_account_activity_uri("webhooks", env_name, None),
+                    &vec![("url", uri)],
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn get_account_activity_webhooks(
+    fn get_account_activity_webhooks(
         &self,
         env_name: Option<&str>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                &make_account_activity_uri("webhooks", env_name, None),
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    &make_account_activity_uri("webhooks", env_name, None),
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
     // Always Fails in Standard(Beta)
-    async fn put_account_activity_webhooks(
+    fn put_account_activity_webhooks(
         &self,
         env_name: Option<&str>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .put(
-                &make_account_activity_uri("webhooks", env_name, None),
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .put(
+                    &make_account_activity_uri("webhooks", env_name, None),
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn delete_account_activity_webhooks(
+    fn delete_account_activity_webhooks(
         &self,
         webhook_id: &str,
         env_name: Option<&str>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .delete(
-                &make_account_activity_uri("webhooks", env_name, Some(webhook_id)),
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .delete(
+                    &make_account_activity_uri("webhooks", env_name, Some(webhook_id)),
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn post_account_activity_subscriptions(
+    fn post_account_activity_subscriptions(
         &self,
         env_name: Option<&str>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .post(
-                &make_account_activity_uri("subscriptions", env_name, None),
-                &vec![],
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .post(
+                    &make_account_activity_uri("subscriptions", env_name, None),
+                    &vec![],
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn get_account_activity_all_count(&self) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                "https://api.twitter.com/1.1/account_activity/all/count.json",
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    fn get_account_activity_all_count(
+        &self,
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    "https://api.twitter.com/1.1/account_activity/all/count.json",
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn get_account_activity_subscriptions(
+    fn get_account_activity_subscriptions(
         &self,
         env_name: Option<&str>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                &make_account_activity_uri("subscriptions", env_name, None),
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    &make_account_activity_uri("subscriptions", env_name, None),
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn get_account_activity_subscriptions_list(
+    fn get_account_activity_subscriptions_list(
         &self,
         env_name: Option<&str>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .get(
-                &make_account_activity_uri("subscriptions", env_name, Some("list")),
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .get(
+                    &make_account_activity_uri("subscriptions", env_name, Some("list")),
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 
-    async fn delete_account_activity_subscriptions(
+    fn delete_account_activity_subscriptions(
         &self,
         env_name: Option<&str>,
-    ) -> Result<TwapiResponse, TwapiError> {
-        let res = self
-            .delete(
-                &make_account_activity_uri("subscriptions", env_name, None),
-                &vec![],
-            )
-            .await?;
-        Ok(TwapiResponse::new(res).await)
+    ) -> impl Future<Output = Result<TwapiResponse, TwapiError>> + Send {
+        async move {
+            let res = self
+                .delete(
+                    &make_account_activity_uri("subscriptions", env_name, None),
+                    &vec![],
+                )
+                .await?;
+            Ok(TwapiResponse::new(res).await)
+        }
     }
 }
 
@@ -539,7 +610,6 @@ impl ApplicationAuth {
     }
 }
 
-#[async_trait]
 impl Twapi for ApplicationAuth {
     async fn get(&self, uri: &str, query_options: &Vec<(&str, &str)>) -> TResult {
         twapi_reqwest::v2::get(uri, query_options, &self.bearer_token, None).await
@@ -600,7 +670,6 @@ impl UserAuth {
     }
 }
 
-#[async_trait]
 impl Twapi for UserAuth {
     async fn get(&self, uri: &str, query_options: &Vec<(&str, &str)>) -> TResult {
         twapi_reqwest::v1::get(


### PR DESCRIPTION
It's been quite some time since `twapi` has gotten some maintenance - this makes a handful of minor changes

* Loosens dependency version requirements for `base64`, `url`, and `serde_urlencoded` to be more permissive to downstream calling crates
* Removes `async-trait` in favor of native async traits
* Updates `twapi-reqwest` to 0.3
* Updates `base64` to 0.22
* Updates `ipnetwork` to 0.20
* Switches to async filesystem I/O in media upload functions
* Eliminates unused `Cursor` for file I/O in media upload functions
* Cleans up assorted `clippy` lints, most notably a couple `.read()` calls that could have caused files to be partially read